### PR TITLE
Read guardians from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,9 @@ steve@steve-VirtualBox:~/projects/pytest_pycharm$ tree -I virtualenv
 
 ```
 
+## revision May 8, 2021
+
+```
+added code to read guardians from a csv file.
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
-appdirs==1.4.4
-distlib==0.3.1
-filelock==3.0.12
-six==1.15.0
-virtualenv==20.4.3
+attrs==21.2.0
+iniconfig==1.1.1
+-e git+https://github.com/steve1281/pytest_pycharm.git@ee430941ec14c9c3f6fa203660cba4a02091cec6#egg=laxleague
+packaging==20.9
+pluggy==0.13.1
+py==1.10.0
+pyparsing==2.4.7
+pytest==6.2.4
+testfixtures==6.17.1
+toml==0.10.2

--- a/src/laxleague/player.py
+++ b/src/laxleague/player.py
@@ -1,3 +1,4 @@
+import csv
 from dataclasses import dataclass, field
 from typing import List, Iterable, Optional
 
@@ -18,5 +19,12 @@ class Player:
     @property
     def primary_guardian(self) -> Optional[Guardian]:
         return self.guardians[0] if self.guardians else None
+
+    def load_guardian_file(self, path):
+        with open(path,newline='') as csvfile:
+            data = csv.reader(csvfile)
+            for row in data:
+                self.guardians.append(Guardian(*row))
+
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
-from typing import Tuple
+from typing import Tuple, List
 
 import pytest
 from laxleague.guardian import Guardian
 from laxleague.player import Player
+from testfixtures import TempDirectory
 
 
 @pytest.fixture
@@ -16,3 +17,22 @@ def guardians() -> Tuple[Guardian, ...]:
     g2 = Guardian('Joanie', 'Johnson')
     g3 = Guardian('Jerry', 'Johnson')
     return g1, g2, g3
+
+
+@pytest.fixture()
+def guardians_file(dir):
+    data = "Mary,Jones\nJoanie,Johnson\nJerry,Johnson"
+    return dir.write("test.csv", data.encode())
+
+
+@pytest.fixture()
+def guardians_list() -> List[Guardian]:
+    return [Guardian(first_name='Mary', last_name='Jones'),
+            Guardian(first_name='Joanie', last_name='Johnson'),
+            Guardian(first_name='Jerry', last_name='Johnson')]
+
+
+@pytest.fixture()
+def dir():
+    with TempDirectory() as d:
+        yield d

--- a/tests/test_guardian.py
+++ b/tests/test_guardian.py
@@ -2,3 +2,5 @@
 def test_construction(guardians):
     assert 'Mary' == guardians[0].first_name
     assert 'Jones' == guardians[0].last_name
+
+

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -35,3 +35,7 @@ def test_primary_guardian(player_one, guardians):
 def test_no_primary_guardian(player_one):
     assert None is player_one.primary_guardian
 
+
+def test_read_guardians_from_csv(player_one, guardians_list, guardians_file):
+    player_one.load_guardian_file(guardians_file)
+    assert player_one.guardians == guardians_list


### PR DESCRIPTION
This PR adds some additional test example, my own, to the original authors work.  In this example, code is added to read guardians in form a csv file.  For testing, fixtures are added to allow for temporary directory and files.